### PR TITLE
botocore 1.23.24

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 1
+  number: 0
   noarch: python
   skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
     - jmespath >=0.7.1,<1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.21.63" %}
-{% set hash = "38c0a98aefc3ff01d9970d84939ff48dd994c49c81cf34ee366860d774852f88" %}
+{% set version = "1.23.24" %}
+{% set hash = "43006b4f52d7bb655319d3da0f615cdbee7762853acc1ebcb1d49f962e6b4806" %}
 
 package:
   name: botocore


### PR DESCRIPTION
Update botocore to 1.23.24

A version 1.23.24 is needed for `aiobotocore 2.1.0` (https://github.com/AnacondaRecipes/aiobotocore-feedstock/pull/9) and -> `s3fs 2022.1.0` (https://github.com/AnacondaRecipes/s3fs-feedstock/pull/12)

Changelog: https://github.com/boto/botocore/blob/1.23.24/CHANGELOG.rst
License: https://github.com/boto/botocore/blob/1.23.24/LICENSE.txt
Upstream setup.py: https://github.com/boto/botocore/blob/1.23.24/setup.py
Upstream setup.cfg: https://github.com/boto/botocore/blob/1.23.24/setup.cfg
Upstream requirements: https://github.com/boto/botocore/blob/1.23.24/requirements-dev.txt

Actions:
1. Reset build number to `0`
2. Add `setuptools`  and `wheel` in `host`