### PR TITLE
botocore 1.24.32

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   noarch: python
-  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
@@ -23,7 +22,7 @@ requirements:
     - wheel
   run:
     - python >=3.6
-    - jmespath >=0.7.1,<1.0.0
+    - jmespath >=0.7.1,<2.0.0
     - python-dateutil >=2.1,<3.0.0
     - urllib3 >=1.25.4,<1.27
 
@@ -38,12 +37,11 @@ test:
     - botocore.vendored.requests.packages.urllib3
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 
 about:
-  home: http://aws.amazon.com/sdk-for-python/
+  home: https://aws.amazon.com/sdk-for-python/
   license_file: LICENSE.txt
   license: Apache-2.0
   license_url: http://aws.amazon.com/apache2.0/


### PR DESCRIPTION
Changelog: https://github.com/boto/botocore/blob/1.24.32/CHANGELOG.rst
License: https://github.com/boto/botocore/blob/1.24.32/LICENSE.txt
Upstream setup.py: https://github.com/boto/botocore/blob/1.24.32/setup.py
Upstream setup.cfg: https://github.com/boto/botocore/blob/1.24.32/setup.cfg
Upstream requirements: https://github.com/boto/botocore/blob/1.24.32/requirements-dev.txt

Actions:
1. Update pinnings for jmespath
2. Remove python <3.10 from test/requires
3. Fix home url with https