### PR TITLE
botocore 1.27.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.24.32" %}
-{% set hash = "5c2dab84f21b2a8c00bdab2150149be0ca0c8e8dd0b38712fa3562af5cfe53a2" %}
+{% set version = "1.27.2" %}
+{% set hash = "b7cdd4f4a6395a084a381a7d2a25b177e6de5f8a4dfa3c645ec957ba3c83e200" %}
 
 package:
   name: botocore
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - jmespath >=0.7.1,<2.0.0
     - python-dateutil >=2.1,<3.0.0
     - urllib3 >=1.25.4,<1.27
@@ -44,7 +44,7 @@ about:
   home: https://aws.amazon.com/sdk-for-python/
   license_file: LICENSE.txt
   license: Apache-2.0
-  license_url: http://aws.amazon.com/apache2.0/
+  license_url: https://aws.amazon.com/apache-2-0/
   license_family: Apache
   summary: Low-level, data-driven core of boto 3.
   description: |


### PR DESCRIPTION
botocore 1.27.2 -> boto3 1.24.2

Changelog: https://github.com/boto/botocore/blob/1.27.2/CHANGELOG.rst
License: https://github.com/boto/botocore/blob/1.27.2/LICENSE.txt
Upstream setup.py: https://github.com/boto/botocore/blob/1.27.2/setup.py
Upstream setup.cfg: https://github.com/boto/botocore/blob/1.27.2/setup.cfg
Upstream requirements: https://github.com/boto/botocore/blob/1.27.2/requirements-dev.txt

Actions:

1. Remove noarch: python
2. Skip py<37
3. Fix python in run
4. Fix license_url