### PR TITLE
Update to 1.27.28

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.27.2" %}
-{% set hash = "b7cdd4f4a6395a084a381a7d2a25b177e6de5f8a4dfa3c645ec957ba3c83e200" %}
+{% set version = "1.27.28" %}
+{% set hash = "b00da6290d8d42c6c3048b045d6537421e8b83e03b4f24bb44c5ea9f37ab6258" %}
 
 package:
   name: botocore


### PR DESCRIPTION
Updating because `boto3-1.24.28` depends on `botocore-1.27.28`.

Changelog: https://github.com/boto/botocore/blob/1.27.28/CHANGELOG.rst
License: https://github.com/boto/botocore/blob/1.27.28/LICENSE.txt
Upstream setup.py: https://github.com/boto/botocore/blob/1.27.28/setup.py
Upstream setup.cfg: https://github.com/boto/botocore/blob/1.27.28/setup.cfg

[Windows Concourse pipeline](https://concourse.build.corp.continuum.io/teams/main/pipelines/pyim_botocore_1.27.28).

Actions:
- Update version and hash.
- Confirmed key dependencies pinnings are up-to-date:
```
    - jmespath >=0.7.1,<2.0.0
    - python-dateutil >=2.1,<3.0.0
    - urllib3 >=1.25.4,<1.27
```