### PR TITLE
botocore 1.27.59

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  scrass_org: s3fs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+- channels:
+-   scrass_org: s3fs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  mesters_org: s3fs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - c3i_test2
+  mesters_org: s3fs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-- channels:
--   scrass_org: s3fs
+channels:
+  scrass_org: s3fs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.27.28" %}
-{% set hash = "b00da6290d8d42c6c3048b045d6537421e8b83e03b4f24bb44c5ea9f37ab6258" %}
+{% set version = "1.27.59" %}
+{% set hash = "eda4aed6ee719a745d1288eaf1beb12f6f6448ad1fa12f159405db14ba9c92cf" %}
 
 package:
   name: botocore

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set version = "1.27.59" %}
 {% set hash = "eda4aed6ee719a745d1288eaf1beb12f6f6448ad1fa12f159405db14ba9c92cf" %}
 
+#Test
 package:
   name: botocore
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set version = "1.27.59" %}
 {% set hash = "eda4aed6ee719a745d1288eaf1beb12f6f6448ad1fa12f159405db14ba9c92cf" %}
 
-#Test
 package:
   name: botocore
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ about:
   description: |
     Provides the core functionality of Boto3, the AWS SDK for Python
   dev_url: https://github.com/boto/botocore
-  doc_url: https://botocore.readthedocs.io/en/latest/
+  doc_url: https://botocore.amazonaws.com/v1/documentation/api/latest/index.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ about:
     Provides the core functionality of Boto3, the AWS SDK for Python
   dev_url: https://github.com/boto/botocore
   doc_url: https://botocore.amazonaws.com/v1/documentation/api/latest/index.html
+  doc_source_url: https://github.com/boto/botocore/tree/{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
+{% set name = "botocore" %}
 {% set version = "1.27.59" %}
 {% set hash = "eda4aed6ee719a745d1288eaf1beb12f6f6448ad1fa12f159405db14ba9c92cf" %}
 
 package:
-  name: botocore
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/b/botocore/botocore-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/botocore-{{ version }}.tar.gz
   sha256: {{ hash }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ build:
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
+#test
 requirements:
   host:
     - python


### PR DESCRIPTION
s3fs 2020.10 --> aiobotocore 2.4.0 --> botocore 1.27.59 #53

Jira ticket: https://anaconda.atlassian.net/browse/PKG-154
Upstream repo: https://github.com/boto/botocore
Changelog: https://github.com/boto/botocore/tree/1.27.59/.changes