### PR TITLE
botocore 1.34.82

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "botocore" %}
-{% set version = "1.32.1" %}
-{% set hash = "fcf3cc2913afba8e5f7ebcc15e8f6bfae844ab64bf983bf5a6fe3bb54cce239d" %}
+{% set version = "1.34.82" %}
+{% set hash = "2fd14676152f9d64541099090cc64973fdf8232744256454de443583e35e497d" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/botocore-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ hash }}
 
 build:
   number: 0
-  skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vvv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --no-build-isolation -vv
 
 #test
 requirements:
@@ -26,8 +26,8 @@ requirements:
     - python
     - jmespath >=0.7.1,<2.0.0
     - python-dateutil >=2.1,<3.0.0
-    - urllib3 >=1.25.4,<1.27  # [py<310]
-    - urllib3 >=1.25.4,<2.1  # [py>=310]
+    - urllib3 >=1.25.4,<1.27       # [py<310]
+    - urllib3 >=1.25.4,!=2.2.0,<3  # [py>=310]
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4612](https://anaconda.atlassian.net/browse/PKG-4612)
- release-notes-tagged: https://github.com/boto/botocore/releases/tag/1.34.82
- release-diff: https://github.com/boto/botocore/compare/1.32.1...1.34.82
- changelog: https://github.com/boto/botocore/blob/1.34.82/CHANGELOG.rst
- license: https://github.com/boto/botocore/blob/develop/LICENSE.txt
- requirements-tagged:
  - https://github.com/boto/botocore/blob/1.34.82/setup.cfg
  - https://github.com/boto/botocore/blob/1.34.82/setup.py


### Explanation of changes:

- Skip py<38
- Update urllib3's pinning for python >=3.10

### Notes:

- The build order of botocore 1.34.82 and downstream packages:
  botocore 1.34.82 -> boto3 1.34.82


[PKG-4612]: https://anaconda.atlassian.net/browse/PKG-4612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ