### PR TITLE
update 1.34.154

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "botocore" %}
-{% set version = "1.34.82" %}
-{% set hash = "2fd14676152f9d64541099090cc64973fdf8232744256454de443583e35e497d" %}
+{% set version = "1.34.154" %}
+{% set hash = "64d9b4c85a504d77cb56dabb2ad717cd8e1717424a88edb458b01d1e5797262a" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
## ☆Botocore 1.34.154 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-5463)
[Upstream](https://github.com/boto/botocore)
# Changes
- Updated version number and `sha256`