### PR TITLE
botocore 1.42.34 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "botocore" %}
-{% set version = "1.42.19" %}
+{% set version = "1.42.34" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/boto/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: b5b33e094bd758b663120d63ba72afef97381c17f9587d4dc07c21db51f3cb04
+  sha256: 8fa2c22b42fb64b4aa120818b72d3cef93908a491d0976374ae3a4486a598e14
 
 build:
   number: 0


### PR DESCRIPTION
botocore 1.42.34 

**Destination channel:** Defaults

### Links

- [PKG-11466]
- dev_url:        https://github.com/boto/botocore/tree/1.42.34
- conda_forge:    https://github.com/conda-forge/botocore-feedstock
- pypi:           https://pypi.org/project/botocore/1.42.34
- pypi inspector: https://inspector.pypi.io/project/botocore/1.42.34

### Explanation of changes:

- new version number


[PKG-11466]: https://anaconda.atlassian.net/browse/PKG-11466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ